### PR TITLE
feat(backend):implemented get endpoint to get an exam

### DIFF
--- a/backend/prisma/migrations/20250908045738_add_savedexam_exam_relation_nullable/migration.sql
+++ b/backend/prisma/migrations/20250908045738_add_savedexam_exam_relation_nullable/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[examId]` on the table `SavedExam` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."SavedExam" ADD COLUMN     "examId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SavedExam_examId_key" ON "public"."SavedExam"("examId");
+
+-- AddForeignKey
+ALTER TABLE "public"."SavedExam" ADD CONSTRAINT "SavedExam_examId_fkey" FOREIGN KEY ("examId") REFERENCES "public"."Exam"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -319,6 +319,8 @@ model Exam {
   questions       ExamQuestion[]
 
   @@index([subject])
+
+  savedExam      SavedExam?
 }
 
 // === Preguntas de Examen ===
@@ -339,6 +341,9 @@ model SavedExam {
   title     String
   content   Json
   status    ExamStorageStatus @default(Guardado)
+
+  examId    String?           @unique
+  exam      Exam?             @relation(fields: [examId], references: [id], onDelete: Cascade)
 
   // FK “lógicas” (sin relación Prisma)
   courseId  String

--- a/backend/src/modules/exams/application/queries/get-exam-by-id.usecase.ts
+++ b/backend/src/modules/exams/application/queries/get-exam-by-id.usecase.ts
@@ -1,0 +1,70 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { PrismaService } from '../../../../core/prisma/prisma.service';
+import { EXAM_REPO, EXAM_QUESTION_REPO, SAVED_EXAM_REPO } from '../../tokens';
+import type { ExamRepositoryPort } from '../../domain/ports/exam.repository.port';
+import type { ExamQuestionRepositoryPort } from '../../domain/ports/exam-question.repository.port';
+import type { SavedExamRepositoryPort } from '../../domain/ports/saved-exam.repository.port';
+import { NotFoundError, UnauthorizedError } from 'src/shared/handler/errors';
+
+export type GetExamByIdQuery = { examId: string; teacherId: string };
+
+@Injectable()
+export class GetExamByIdUseCase {
+    constructor(
+        private readonly prisma: PrismaService,
+        @Inject(EXAM_REPO) private readonly examRepo: ExamRepositoryPort,
+        @Inject(EXAM_QUESTION_REPO) private readonly questionRepo: ExamQuestionRepositoryPort,
+        @Inject(SAVED_EXAM_REPO) private readonly savedRepo: SavedExamRepositoryPort,
+    ) {}
+
+    async execute(q: GetExamByIdQuery) {
+    // SavedExam binds examId to a teacher and course (ownership)
+        const saved = await this.savedRepo.findByExamId(q.examId);
+        if (!saved) throw new NotFoundError('Examen no encontrado');
+        if (saved.teacherId !== q.teacherId) throw new UnauthorizedError('Acceso no autorizado');
+
+    const exam = await this.examRepo.findById(q.examId);
+        if (!exam) throw new NotFoundError('Examen no encontrado');
+
+    const questions = await this.questionRepo.listByExam(q.examId);
+
+    const raw = typeof (exam as any).toJSON === 'function' ? (exam as any).toJSON() : exam as any;
+    const distribution =
+        'mcqCount' in raw ||
+        'trueFalseCount' in raw ||
+        'openAnalysisCount' in raw ||
+        'openExerciseCount' in raw
+    ? {
+        multiple_choice: raw.mcqCount ?? 0,
+        true_false: raw.trueFalseCount ?? 0,
+        open_analysis: raw.openAnalysisCount ?? 0,
+        open_exercise: raw.openExerciseCount ?? 0,
+    }
+    : null;
+
+    // JSON ready for FE
+    const base = exam.toJSON();
+        return {
+            id: exam.id,
+            title: saved.title,
+            date: saved.createdAt,
+            status: saved.status,         // Guardado | Publicado
+            subject: base.subject,
+            difficulty: base.difficulty,
+            totalQuestions: base.totalQuestions,
+            timeMinutes: base.timeMinutes,
+            reference: base.reference ?? null,
+            distribution,
+            questions: questions.map(q => ({
+                id: q.id,
+                kind: q.kind,                // MCQ | TRUE_FALSE | OPEN_ANALYSIS | OPEN_EXERCISE
+                text: q.text,
+                options: q.options ?? null,
+                correctOptionIndex: q.correctOptionIndex ?? null,
+                correctBoolean: q.correctBoolean ?? null,
+                expectedAnswer: q.expectedAnswer ?? null,
+                order: q.order,
+            })),
+        };
+    }
+}

--- a/backend/src/modules/exams/domain/ports/exam-question.repository.port.ts
+++ b/backend/src/modules/exams/domain/ports/exam-question.repository.port.ts
@@ -20,4 +20,5 @@ export interface ExamQuestionRepositoryPort {
 
   findById(id: string): Promise<ExamQuestion | null>;
   update(id: string, patch: UpdateExamQuestionPatch): Promise<ExamQuestion>;
+  listByExam(examId: string): Promise<ExamQuestion[]>;
 }

--- a/backend/src/modules/exams/domain/ports/saved-exam.repository.port.ts
+++ b/backend/src/modules/exams/domain/ports/saved-exam.repository.port.ts
@@ -17,7 +17,21 @@ export interface SavedExamDTO {
   source?: 'saved' | 'hardcoded';
 }
 
+export type SavedExamStatus = 'Guardado' | 'Publicado';
+
+export type SavedExamReadModel = {
+  id: number;
+  title: string;
+  content: unknown; 
+  status: SavedExamStatus;  
+  courseId: string;
+  teacherId: string;
+  createdAt: Date;
+  examId: string | null; 
+};
+
 export interface SavedExamRepositoryPort {
   save(data: SaveApprovedExamInput): Promise<SavedExamDTO>;
   listByCourse(courseId: string, teacherId?: string): Promise<SavedExamDTO[]>;
+  findByExamId(examId: string): Promise<SavedExamReadModel | null>;
 }

--- a/backend/src/modules/exams/exams.module.ts
+++ b/backend/src/modules/exams/exams.module.ts
@@ -17,6 +17,7 @@ import { ApproveExamCommandHandler } from './application/commands/approve-exam.h
 import { SavedExamPrismaRepository } from './infrastructure/persistence/saved-exam.prisma.repository';
 import { SaveApprovedExamUseCase } from './application/commands/save-approved-exam.usecase';
 import { ListCourseExamsUseCase } from './application/queries/list-course-exams.usecase';
+import { GetExamByIdUseCase } from './application/queries/get-exam-by-id.usecase';
 import { SAVED_EXAM_REPO, COURSE_EXAMS_HARDCODED } from './tokens';
 import { SimpleCourseExamsProvider } from './infrastructure/http/providers/course-hardcoded-exams.provider';
 import { ApprovedExamsController } from './infrastructure/http/approved-exams.controller';
@@ -67,6 +68,7 @@ const DevTokenService = {
     ApproveExamCommandHandler,
     SaveApprovedExamUseCase,
     ListCourseExamsUseCase,
+    GetExamByIdUseCase,
     
     { provide: TOKEN_SERVICE, useValue: DevTokenService },
   ],

--- a/backend/src/modules/exams/infrastructure/http/approved-exams.controller.ts
+++ b/backend/src/modules/exams/infrastructure/http/approved-exams.controller.ts
@@ -1,10 +1,12 @@
 import { Body, Controller, Get, Param, Post, Req, UseGuards, BadRequestException, ForbiddenException, } from '@nestjs/common';
 import type { Request } from 'express';
 import { JwtAuthGuard } from 'src/shared/guards/jwt-auth.guard';
-import { responseSuccess, responseBadRequest, responseForbidden, responseInternalServerError, } from 'src/shared/handler/http.handler';
+import { responseSuccess, responseBadRequest, responseForbidden, responseInternalServerError, responseNotFound, } from 'src/shared/handler/http.handler';
 import { SaveApprovedExamDto } from './dtos/save-approved-exam.dto';
 import { SaveApprovedExamUseCase } from '../../application/commands/save-approved-exam.usecase';
 import { ListCourseExamsUseCase } from '../../application/queries/list-course-exams.usecase';
+import { GetExamByIdUseCase } from '../../application/queries/get-exam-by-id.usecase';
+import * as crypto from 'crypto';
 
 const cid = (req: Request) => req.header('x-correlation-id') ?? crypto.randomUUID();
 const pathOf = (req: Request) => (req as any).originalUrl || req.url || '';
@@ -15,6 +17,7 @@ export class ApprovedExamsController {
   constructor(
     private readonly saveUseCase: SaveApprovedExamUseCase,
     private readonly listUseCase: ListCourseExamsUseCase,
+    private readonly getByIdUseCase: GetExamByIdUseCase,
   ) {}
 
   @Post('exams/approved')
@@ -60,4 +63,28 @@ export class ApprovedExamsController {
       return responseInternalServerError('Error interno', cid(req), msg, pathOf(req));
     }
   }
+
+
+  @Get('/exams/:examId')
+  async getExamById(@Param('examId') examId: string, @Req() req: Request) {
+    const user = (req as any).user as { sub: string } | undefined;
+    if (!user?.sub) {
+      return responseForbidden('Acceso no autorizado', cid(req), 'Falta token', pathOf(req));
+    }
+
+    try {
+      const data = await this.getByIdUseCase.execute({ examId, teacherId: user.sub });
+      return responseSuccess(cid(req), data, 'Examen recuperado', pathOf(req));
+    } catch (e: any) {
+      const msg = (e?.message ?? '').toString();
+      if (msg.includes('Acceso no autorizado')) {
+        return responseForbidden('Acceso no autorizado', cid(req), msg, pathOf(req));
+      }
+      if (msg.includes('Examen no encontrado')) {
+        return responseNotFound('Examen no encontrado', cid(req), msg, pathOf(req));
+      }
+      return responseInternalServerError('Error interno', cid(req), msg || 'Error obteniendo examen', pathOf(req));
+    }
+  }
+
 }

--- a/backend/src/modules/exams/infrastructure/persistence/exam-question.prisma.repository.ts
+++ b/backend/src/modules/exams/infrastructure/persistence/exam-question.prisma.repository.ts
@@ -120,4 +120,25 @@ export class ExamQuestionPrismaRepository implements ExamQuestionRepositoryPort 
       updatedAt: updated.updatedAt,
     };
   }
+
+    async listByExam(examId: string) {
+    const rows = await this.prisma.examQuestion.findMany({
+      where: { examId },
+      orderBy: { order: 'asc' },
+    });
+    return rows.map((row) => ({
+      id: row.id,
+      examId: row.examId,
+      kind: row.kind as any,
+      text: row.text,
+      options: (row as any).options ?? undefined,
+      correctOptionIndex: row.correctOptionIndex ?? undefined,
+      correctBoolean: row.correctBoolean ?? undefined,
+      expectedAnswer: row.expectedAnswer ?? undefined,
+      order: row.order,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    }));
+  }
+
 }

--- a/backend/src/modules/exams/infrastructure/persistence/exam.prisma.repository.ts
+++ b/backend/src/modules/exams/infrastructure/persistence/exam.prisma.repository.ts
@@ -5,6 +5,7 @@ import { Exam } from '../../domain/entities/exam.entity';
 import { Difficulty } from '../../domain/entities/difficulty.vo';
 import { PositiveInt } from '../../domain/entities/positive-int.vo';
 import { DistributionVO } from '../../domain/entities/distribution.vo';
+import { SavedExamDTO } from '../../domain/ports/saved-exam.repository.port';
 
 @Injectable()
 export class ExamPrismaRepository implements ExamRepositoryPort {
@@ -116,6 +117,23 @@ export class ExamPrismaRepository implements ExamRepositoryPort {
       data: { approvedAt: new Date() },
     });
     this.logger.log(`approve <- id=${id}`);
+  }
+
+    async findByExamId(examId: string): Promise<SavedExamDTO | null> {
+    const r = await this.prisma.savedExam.findUnique({
+      where: { examId },
+    });
+    if (!r) return null;
+    return {
+      id: r.id,
+      title: r.title,
+      content: r.content,
+      status: r.status as any,
+      courseId: r.courseId,
+      teacherId: r.teacherId,
+      createdAt: r.createdAt,
+      source: 'saved',
+    };
   }
 
 }


### PR DESCRIPTION
to run the new changes:
`npx prisma migrate reset`
`npx prisma generate`
`npx prisma db push` or `npx prisma migrate dev`
`npm run seed`

to test:
create a GET request in postman with endpoint localhost:3000/exams/:examsId


